### PR TITLE
Fix dashboard columns export name

### DIFF
--- a/src/app/(main)/dashboard/default/_components/columns.tsx
+++ b/src/app/(main)/dashboard/default/_components/columns.tsx
@@ -22,9 +22,10 @@
 */
 
 import { ColumnDef } from "@tanstack/react-table";
+
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
-import { Checkbox } from "@/components/ui/checkbox";
 import { ReceiptRowActions } from "@/components/table/row-actions";
+import { Checkbox } from "@/components/ui/checkbox";
 
 // ────────────────────────────────────────────────────────────
 //  Tipi
@@ -55,7 +56,7 @@ const fmtNum  = (val?: number) => (val ?? "—");
 // ────────────────────────────────────────────────────────────
 //  Definizione colonne
 // ────────────────────────────────────────────────────────────
-export const columns: ColumnDef<ReceiptRow>[] = [
+export const dashboardColumns: ColumnDef<ReceiptRow>[] = [
   // Checkbox di selezione (fissa)
   {
     id: "select",

--- a/src/app/(main)/dashboard/default/_components/data-table.tsx
+++ b/src/app/(main)/dashboard/default/_components/data-table.tsx
@@ -27,7 +27,7 @@ import { DataTablePagination } from "../../../../../components/data-table/data-t
 import { DataTableViewOptions } from "../../../../../components/data-table/data-table-view-options";
 import { withDndColumn } from "../../../../../components/data-table/table-utils";
 
-import { dashboardColumns } from "./columns";
+import { dashboardColumns, type ReceiptRow } from "./columns";
 
 export const schema = z.object({
   id: z.number(),
@@ -39,12 +39,16 @@ export const schema = z.object({
   reviewer: z.string(),
 });
 
-export function DataTable({ data: initialData }: { data: z.infer<typeof schema>[] }) {
+export function DataTable({ data: initialData }: { data: ReceiptRow[] }) {
   const dndEnabled = true;
 
-  const [data, setData] = React.useState(() => initialData);
+  const [data, setData] = React.useState<ReceiptRow[]>(() => initialData);
   const columns = dndEnabled ? withDndColumn(dashboardColumns) : dashboardColumns;
-  const table = useDataTableInstance({ data, columns, getRowId: (row) => row.id.toString() });
+  const table = useDataTableInstance<ReceiptRow, unknown>({
+    data,
+    columns,
+    getRowId: (row) => row.id.toString(),
+  });
   const sortableId = React.useId();
   const sensors = useSensors(useSensor(MouseSensor, {}), useSensor(TouchSensor, {}), useSensor(KeyboardSensor, {}));
   const dataIds = React.useMemo<UniqueIdentifier[]>(() => data?.map(({ id }) => id) || [], [data]);

--- a/src/app/(main)/dashboard/default/page.tsx
+++ b/src/app/(main)/dashboard/default/page.tsx
@@ -1,4 +1,5 @@
 import { ChartAreaInteractive } from "./_components/chart-area-interactive";
+import type { ReceiptRow } from "./_components/columns";
 import { DataTable } from "./_components/data-table";
 import data from "./_components/data.json";
 import { SectionCards } from "./_components/section-cards";
@@ -8,7 +9,7 @@ export default function Page() {
     <div className="@container/main flex flex-col gap-4 md:gap-6">
       <SectionCards />
       <ChartAreaInteractive />
-      <DataTable data={data} />
+      <DataTable data={data as unknown as ReceiptRow[]} />
     </div>
   );
 }

--- a/src/components/table/row-actions.tsx
+++ b/src/components/table/row-actions.tsx
@@ -2,6 +2,7 @@
 
 import { Copy, Edit, MoreHorizontal, Trash } from "lucide-react";
 
+import type { ReceiptRow } from "@/app/(main)/dashboard/default/_components/columns";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -11,7 +12,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { ReceiptRow } from "@/app/(main)/dashboard/default/_components/columns";
 
 export function ReceiptRowActions({ row }: { row: ReceiptRow }) {
   return (
@@ -24,9 +24,7 @@ export function ReceiptRowActions({ row }: { row: ReceiptRow }) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-40">
         <DropdownMenuLabel>Actions</DropdownMenuLabel>
-        <DropdownMenuItem
-          onClick={() => navigator.clipboard.writeText(row.id.toString())}
-        >
+        <DropdownMenuItem onClick={() => navigator.clipboard.writeText(row.id.toString())}>
           <Copy className="size-4" />
           <span>Copy ID</span>
         </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- rename `columns` export to `dashboardColumns`
- update data table and related imports to use new name
- cast data to `ReceiptRow` type for dashboard table
- adjust import order per lint rules

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b58741b9c8325b3640edd42d97da1