### PR TITLE
Install eslint-plugin-next and reference in config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ import securityPlugin from "eslint-plugin-security";
 import prettier from "eslint-plugin-prettier";
 import unicorn from "eslint-plugin-unicorn";
 import sonarjs from "eslint-plugin-sonarjs";
+import eslintPluginNext from "eslint-plugin-next";
 
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
@@ -30,13 +31,14 @@ export default [
         version: "detect",
       },
     },
-    plugins: {
+   plugins: {
       import: pluginImport,
       security: securityPlugin,
       prettier: prettier,
       unicorn: unicorn,
       react: pluginReact,
       sonarjs: sonarjs,
+      next: eslintPluginNext,
     },
   },
   pluginJs.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "eslint": "^9.28.0",
         "eslint-config-next": "^15.3.3",
         "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-next": "npm:@next/eslint-plugin-next@^15.3.3",
         "eslint-plugin-prettier": "^5.4.1",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-security": "^3.0.1",
@@ -956,6 +957,7 @@
       "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.3.tgz",
       "integrity": "sha512-VKZJEiEdpKkfBmcokGjHu0vGDG+8CehGs90tBEy/IDoDDKGngeyIStt2MmE5FYNyU9BhgR7tybNWTAJY/30u+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-glob": "3.3.1"
       }
@@ -4953,6 +4955,47 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-next": {
+      "name": "@next/eslint-plugin-next",
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.3.tgz",
+      "integrity": "sha512-VKZJEiEdpKkfBmcokGjHu0vGDG+8CehGs90tBEy/IDoDDKGngeyIStt2MmE5FYNyU9BhgR7tybNWTAJY/30u+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/eslint-plugin-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/eslint-plugin-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint": "^9.28.0",
     "eslint-config-next": "^15.3.3",
     "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-next": "npm:@next/eslint-plugin-next@^15.3.3",
     "eslint-plugin-prettier": "^5.4.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-security": "^3.0.1",


### PR DESCRIPTION
## Summary
- install `eslint-plugin-next` as an alias to `@next/eslint-plugin-next`
- import the plugin in `eslint.config.mjs`
- register the plugin as `next`

## Testing
- `npm run lint` *(fails: Next.js plugin not detected)*

------
https://chatgpt.com/codex/tasks/task_e_684b5882ad2c8325b6da2d2afc448817