### PR TITLE
Update Drizzle scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
-    "generate:migrations": "drizzle-kit generate:pg",
-    "push:migrations": "drizzle-kit push:pg"
+    "generate:migrations": "drizzle-kit generate --schema=./lib/schema.ts --out=./drizzle",
+    "push:migrations": "drizzle-kit push --schema=./lib/schema.ts --out=./drizzle"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [


### PR DESCRIPTION
## Summary
- update `drizzle-kit` scripts to new syntax and include required options

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b6971dfb883258e5556b9af909fd8