### PR TITLE
Fix receipts archive migration

### DIFF
--- a/drizzle/0000_futuristic_vapor.sql
+++ b/drizzle/0000_futuristic_vapor.sql
@@ -1,5 +1,21 @@
 CREATE TABLE "receipts_archive" (
-	"archived_at" timestamp DEFAULT now()
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"date" timestamp NOT NULL,
+	"time" varchar,
+	"name" varchar NOT NULL,
+	"country" varchar,
+	"currency" varchar NOT NULL,
+	"total" numeric(12, 2) NOT NULL,
+	"tip" numeric(12, 2),
+	"exchange_rate" numeric(12, 6),
+	"total_eur" numeric(12, 2),
+	"percent" numeric(5, 2),
+	"payment_method" varchar,
+	"status" varchar DEFAULT 'new',
+	"source_hash" text NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"archived_at" timestamp DEFAULT now(),
+	CONSTRAINT "receipts_live_source_hash_unique" UNIQUE("source_hash")
 );
 --> statement-breakpoint
 CREATE TABLE "receipts_live" (

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "bea0826e-1a66-4008-9a9e-b2a75535b808",
+  "id": "5d0b521f-cb94-4e94-96cf-c543ff15fc07",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -8,6 +8,99 @@
       "name": "receipts_archive",
       "schema": "",
       "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tip": {
+          "name": "tip",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_eur": {
+          "name": "total_eur",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent": {
+          "name": "percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'new'"
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
         "archived_at": {
           "name": "archived_at",
           "type": "timestamp",
@@ -19,7 +112,15 @@
       "indexes": {},
       "foreignKeys": {},
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "uniqueConstraints": {
+        "receipts_live_source_hash_unique": {
+          "name": "receipts_live_source_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_hash"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1749771972105,
-      "tag": "0000_stormy_firebird",
+      "when": 1749772815727,
+      "tag": "0000_futuristic_vapor",
       "breakpoints": true
     }
   ]

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,7 +1,12 @@
 import { pgTable, uuid, varchar, numeric, timestamp, text } from "drizzle-orm/pg-core";
 
-/* --- live ------------------------------------------------ */
-export const receiptsLive = pgTable("receipts_live", {
+/*
+ * Columns shared between the live and archive tables. Drizzle relies on the
+ * column definitions passed directly to `pgTable` to infer the table shape
+ * when generating migrations, so we keep these definitions in a standalone
+ * object that can be spread into both table definitions.
+ */
+const receiptColumns = {
   id: uuid("id").primaryKey().defaultRandom(),
   date: timestamp("date", { mode: "date" }).notNull(),
   time: varchar("time", 8),
@@ -17,10 +22,13 @@ export const receiptsLive = pgTable("receipts_live", {
   status: varchar("status", 20).default("new"),
   sourceHash: text("source_hash").notNull().unique(),
   createdAt: timestamp("created_at").defaultNow(),
-});
+};
+
+/* --- live ------------------------------------------------ */
+export const receiptsLive = pgTable("receipts_live", receiptColumns);
 
 /* --- archivio ------------------------------------------- */
 export const receiptsArchive = pgTable("receipts_archive", {
-  ...receiptsLive.columns,
+  ...receiptColumns,
   archivedAt: timestamp("archived_at").defaultNow(),
 });


### PR DESCRIPTION
## Summary
- define shared columns for receipt tables
- regenerate migration with all columns for `receipts_archive`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684b696b52d483258a1140146e88a60a