### PR TITLE
Fix UI directory ignore in Prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,4 +9,4 @@ postcss.config.mjs
 README.md
 tsconfig.json
 .env
-src/components/ui
+src/components/ui/


### PR DESCRIPTION
## Summary
- add missing newline to `.prettierignore`
- ensure UI primitives folder is excluded using a trailing slash

## Testing
- `npx prettier . --write`

------
https://chatgpt.com/codex/tasks/task_e_684b761c6f248325a95c5cfa61f8627d