### PR TITLE
Fix lint issue in sidebar search dialog

### DIFF
--- a/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
@@ -63,7 +63,6 @@ export function SearchDialog() {
                     <CommandItem className="!py-1.5" key={item.label} onSelect={() => setOpen(false)}>
                       {item.icon && <item.icon />}
                       <span>{item.label}</span>
-                      {/* {item.shortcut && <CommandShortcut>{item.shortcut}</CommandShortcut>} */}
                     </CommandItem>
                   ))}
               </CommandGroup>


### PR DESCRIPTION
## Summary
- remove commented `CommandShortcut` JSX in SearchDialog sidebar component

## Testing
- `pnpm lint --file src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx`

------
https://chatgpt.com/codex/tasks/task_e_684b76154b9c832597a84be33e8b76e5