### PR TITLE
Fix Next ESLint plugin configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ import securityPlugin from "eslint-plugin-security";
 import prettier from "eslint-plugin-prettier";
 import unicorn from "eslint-plugin-unicorn";
 import sonarjs from "eslint-plugin-sonarjs";
-import eslintPluginNext from "eslint-plugin-next";
+import eslintPluginNext from "@next/eslint-plugin-next";
 
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
@@ -17,7 +17,7 @@ const compat = new FlatCompat({
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
-  { ignores: [".github/", ".husky/", "node_modules/", ".next/", "src/components/ui", "*.config.ts", "*.mjs"] },
+  { ignores: [".github/", ".husky/", "node_modules/", ".next/", "src/components/ui", "*.config.ts"] },
   {
     languageOptions: {
       globals: globals.browser,
@@ -38,7 +38,7 @@ export default [
       unicorn: unicorn,
       react: pluginReact,
       sonarjs: sonarjs,
-      next: eslintPluginNext,
+      "@next/next": eslintPluginNext,
     },
   },
   pluginJs.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "eslint": "^9.28.0",
     "eslint-config-next": "^15.3.3",
     "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-next": "npm:@next/eslint-plugin-next@^15.3.3",
+    "@next/eslint-plugin-next": "^15.3.3",
     "eslint-plugin-prettier": "^5.4.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-security": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       '@eslint/js':
         specifier: ^9.16.0
         version: 9.28.0
+      '@next/eslint-plugin-next':
+        specifier: ^15.3.3
+        version: 15.3.3
       '@tailwindcss/postcss':
         specifier: ^4.1.9
         version: 4.1.10
@@ -222,9 +225,6 @@ importers:
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-next:
-        specifier: npm:@next/eslint-plugin-next@^15.3.3
-        version: '@next/eslint-plugin-next@15.3.3'
       eslint-plugin-prettier:
         specifier: ^5.4.1
         version: 5.4.1(eslint@9.28.0(jiti@2.4.2))(prettier@3.5.3)


### PR DESCRIPTION
## Summary
- use `@next/eslint-plugin-next`
- add plugin to config with new name
- update ignores to allow loading the ESLint config

## Testing
- `pnpm install`
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_684b79e72b9c8325a618621b63a58f47