### PR TITLE
Fix sensor generic for DnD table

### DIFF
--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -19,7 +19,7 @@ interface DataTableProps<TData, TValue> {
   dataIds?: UniqueIdentifier[];
   dndEnabled?: boolean;
   handleDragEnd?: (event: DragEndEvent) => void;
-  sensors?: SensorDescriptor[];
+  sensors?: SensorDescriptor<any>[];
   sortableId?: string;
 }
 


### PR DESCRIPTION
## Summary
- update `DataTableProps` sensors type to specify generic parameter
- ensure data table usage is unchanged

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm build` *(fails: getRowId type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684b79e505f0832593228745d5ed69df