### PR TITLE
Fix getRowId signature in data table hook

### DIFF
--- a/src/hooks/use-data-table-instance.ts
+++ b/src/hooks/use-data-table-instance.ts
@@ -5,6 +5,7 @@ import {
   ColumnFiltersState,
   SortingState,
   VisibilityState,
+  Row,
   getCoreRowModel,
   getFacetedRowModel,
   getFacetedUniqueValues,
@@ -20,7 +21,7 @@ type UseDataTableInstanceProps<TData, TValue> = {
   enableRowSelection?: boolean;
   defaultPageIndex?: number;
   defaultPageSize?: number;
-  getRowId?: (row: TData, index: number) => string;
+  getRowId?: (row: TData, index: number, parent?: Row<TData>) => string;
 };
 
 export function useDataTableInstance<TData, TValue>({
@@ -51,7 +52,13 @@ export function useDataTableInstance<TData, TValue>({
       pagination,
     },
     enableRowSelection,
-    getRowId: getRowId ?? ((row: TData & { id: string | number }) => String(row.id)),
+    getRowId:
+      getRowId ??
+      ((row: TData, _index: number, _parent?: Row<TData>) => {
+        void _index;
+        void _parent;
+        return String((row as { id: string | number }).id);
+      }),
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,


### PR DESCRIPTION
## Summary
- update `use-data-table-instance` to match react-table's `getRowId` signature
- ensure default `getRowId` handles optional params

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b7c3a5eac8325a0a3de04e5d10582