### PR TITLE
Fix getRowId signature mismatch

### DIFF
--- a/src/hooks/use-data-table-instance.ts
+++ b/src/hooks/use-data-table-instance.ts
@@ -12,6 +12,7 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
+  type Row,
 } from "@tanstack/react-table";
 
 type UseDataTableInstanceProps<TData, TValue> = {
@@ -51,7 +52,11 @@ export function useDataTableInstance<TData, TValue>({
       pagination,
     },
     enableRowSelection,
-    getRowId: getRowId ?? ((row: TData & { id: string | number }) => String(row.id)),
+    getRowId: getRowId
+      ? (row: TData, index: number, parent?: Row<TData>) =>
+          getRowId(row, index)
+      : (row: TData, index: number, parent?: Row<TData>) =>
+          String((row as { id: string | number }).id),
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,


### PR DESCRIPTION
## Summary
- align `getRowId` with the expected RowIdFunction signature in `use-data-table-instance`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b9e8d13b4832594b7f784f0ad1ec9