### PR TITLE
Update README dashboard paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The current version uses the [Tweakcn Tangerine](https://tweakcn.com/) theme for
 🚧 Coming Soon
 
 ### Dashboards
-- ✅ Default
+- ✅ Andamento
 - 🚧 CRM
 - 🚧 Analytics
 - 🚧 eCommerce
@@ -77,7 +77,7 @@ src/
 │   ├── (main)/               # Main application layout
 │   │   ├── dashboard/
 │   │   │   ├── layout.tsx    # Shared layout for dashboard routes
-│   │   │   ├── default/      # Default overview dashboard
+│   │   │   ├── andamento/    # Main overview dashboard
 │   │   │   │   ├── components/
 │   │   │   │   └── page.tsx
 │   │   │   ├── ecommerce/


### PR DESCRIPTION
## Summary
- rename default dashboard references to `andamento`

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npm run format:check` *(fails: missing `prettier-plugin-tailwindcss`)*

------
https://chatgpt.com/codex/tasks/task_e_684d5de52ee48325826395666bedb01e