### PR TITLE
Add reusable KPI card and cost metrics endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "initials": "^3.1.2",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.453.0",
+    "swr": "^2.3.3",
     "next": "^15.3.3",
     "next-themes": "^0.4.6",
     "react": "^19.1.0",

--- a/src/app/(main)/dashboard/andamento/page.tsx
+++ b/src/app/(main)/dashboard/andamento/page.tsx
@@ -2,14 +2,19 @@ import { ChartAreaInteractive } from "./_components/chart-area-interactive";
 import type { ReceiptRow } from "./_components/columns";
 import { DataTable } from "./_components/data-table";
 import data from "./_components/data.json";
-import { SectionCards } from "./_components/section-cards";
+import { KpiCardGroup } from "@/components/kpi/KpiCardGroup";
+import useSWR from "swr";
 
-export default function Page() {
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function Andamento() {
+  const { data: metrics } = useSWR("/api/dashboard/metrics", fetcher);
+
   return (
-    <div className="@container/main flex flex-col gap-4 md:gap-6">
-      <SectionCards />
+    <main className="p-4 md:p-8 flex flex-col gap-6">
+      <KpiCardGroup data={metrics?.overview ?? []} />
       <ChartAreaInteractive />
       <DataTable data={data as unknown as ReceiptRow[]} />
-    </div>
+    </main>
   );
 }

--- a/src/app/(main)/dashboard/costi/page.tsx
+++ b/src/app/(main)/dashboard/costi/page.tsx
@@ -1,3 +1,15 @@
-export default function Page() {
-  return <div className="@container/main flex flex-col gap-4 md:gap-6" />;
+import { KpiCardGroup } from "@/components/kpi/KpiCardGroup";
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function Costi() {
+  const { data, isLoading } = useSWR("/api/dashboard/costi-metrics", fetcher);
+
+  return (
+    <main className="p-4 md:p-8 flex flex-col gap-6">
+      {isLoading ? <p>Loading…</p> : <KpiCardGroup data={data} />}
+      {/* qui sotto la DataTable costi */}
+    </main>
+  );
 }

--- a/src/app/api/dashboard/costi-metrics/route.ts
+++ b/src/app/api/dashboard/costi-metrics/route.ts
@@ -1,0 +1,20 @@
+import { db } from "@/lib/db";
+import { receiptsLive } from "@/lib/schema";
+import { sum, eq } from "drizzle-orm";
+
+export async function GET() {
+  const total = await db
+    .select({ value: sum(receiptsLive.totalEur) })
+    .from(receiptsLive)
+    .where(eq(receiptsLive.status, "new"));
+
+  return Response.json([
+    {
+      title: "Costo totale",
+      value: total[0]?.value ?? 0,
+      delta: "+0%",
+      subtitle: "Spese mese in corso",
+      footer: "Dati live",
+    },
+  ]);
+}

--- a/src/app/api/dashboard/metrics/route.ts
+++ b/src/app/api/dashboard/metrics/route.ts
@@ -1,0 +1,34 @@
+export async function GET() {
+  return Response.json({
+    overview: [
+      {
+        title: "Total Revenue",
+        value: "$1,250.00",
+        delta: "+0%",
+        subtitle: "Trending up this month",
+        footer: "Visitors for the last 6 months",
+      },
+      {
+        title: "New Customers",
+        value: "1,234",
+        delta: "-20%",
+        subtitle: "Down 20% this period",
+        footer: "Acquisition needs attention",
+      },
+      {
+        title: "Active Accounts",
+        value: "45,678",
+        delta: "+12.5%",
+        subtitle: "Strong user retention",
+        footer: "Engagement exceed targets",
+      },
+      {
+        title: "Growth Rate",
+        value: "4.5%",
+        delta: "+4.5%",
+        subtitle: "Steady performance increase",
+        footer: "Meets growth projections",
+      },
+    ],
+  });
+}

--- a/src/components/kpi/KpiCardGroup.tsx
+++ b/src/components/kpi/KpiCardGroup.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+interface CardDef {
+  title: string;
+  value: string | number;
+  delta: string;
+  subtitle: string;
+  footer: string;
+}
+
+interface Props {
+  data: CardDef[];
+}
+
+export function KpiCardGroup({ data }: Props) {
+  return (
+    <div className="grid gap-4 md:grid-cols-4">
+      {data.map((c) => (
+        <Card key={c.title}>
+          <CardContent className="p-6">
+            <h3 className="text-sm font-medium text-muted-foreground">
+              {c.title}
+            </h3>
+            <div className="flex items-center justify-between">
+              <span className="text-3xl font-bold">{c.value}</span>
+              <span className="rounded-md bg-muted px-2 py-0.5 text-xs">
+                {c.delta}
+              </span>
+            </div>
+            <p className="mt-3 text-sm">{c.subtitle}</p>
+            <p className="text-xs text-muted-foreground">{c.footer}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add swr dependency
- create `KpiCardGroup` reusable component
- load metrics via SWR in andamento dashboard
- implement costi dashboard page with metrics
- add `metrics` and `costi-metrics` API routes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run format:check` *(fails: `prettier-plugin-tailwindcss` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d831e2a84832580b96565dca5afe9