### PR TITLE
Add cost metrics dashboard

### DIFF
--- a/src/app/(main)/dashboard/costi/page.tsx
+++ b/src/app/(main)/dashboard/costi/page.tsx
@@ -1,3 +1,12 @@
-export default function Page() {
-  return <div className="@container/main flex flex-col gap-4 md:gap-6" />;
+import { KpiCardGroup, KpiMetric } from "@/components/kpi-card-group";
+
+export default async function Page() {
+  const res = await fetch("/api/dashboard/costi-metrics");
+  const metrics: KpiMetric[] = await res.json();
+
+  return (
+    <div className="@container/main flex flex-col gap-4 md:gap-6">
+      <KpiCardGroup metrics={metrics} />
+    </div>
+  );
 }

--- a/src/app/api/dashboard/costi-metrics/route.ts
+++ b/src/app/api/dashboard/costi-metrics/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+export interface CostMetric {
+  title: string;
+  value: string;
+  delta: string;
+  deltaType: "increase" | "decrease";
+  comment: string;
+  subcomment: string;
+}
+
+export async function GET() {
+  const metrics: CostMetric[] = [
+    {
+      title: "Total Costs",
+      value: "$12,340",
+      delta: "+5%",
+      deltaType: "increase",
+      comment: "Up from last month",
+      subcomment: "Total expenses for the last 30 days",
+    },
+    {
+      title: "New Expenses",
+      value: "45",
+      delta: "-3%",
+      deltaType: "decrease",
+      comment: "Fewer bills this month",
+      subcomment: "Compared to previous period",
+    },
+    {
+      title: "Avg. Cost",
+      value: "$275",
+      delta: "+2%",
+      deltaType: "increase",
+      comment: "Average per item",
+      subcomment: "All expenses in database",
+    },
+    {
+      title: "Recurring Costs",
+      value: "$2,500",
+      delta: "+10%",
+      deltaType: "increase",
+      comment: "More subscriptions",
+      subcomment: "Monthly recurring charges",
+    },
+  ];
+
+  return NextResponse.json(metrics);
+}

--- a/src/components/kpi-card-group.tsx
+++ b/src/components/kpi-card-group.tsx
@@ -1,0 +1,45 @@
+import { TrendingDown, TrendingUp } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardAction, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+export interface KpiMetric {
+  title: string;
+  value: string;
+  delta: string;
+  deltaType: "increase" | "decrease";
+  comment: string;
+  subcomment: string;
+}
+
+export function KpiCardGroup({ metrics }: { metrics: KpiMetric[] }) {
+  return (
+    <div className="*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+      {metrics.map((metric, index) => (
+        <Card className="@container/card" key={index}>
+          <CardHeader>
+            <CardDescription>{metric.title}</CardDescription>
+            <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">{metric.value}</CardTitle>
+            <CardAction>
+              <Badge variant="outline">
+                {metric.deltaType === "increase" ? <TrendingUp /> : <TrendingDown />}
+                {metric.delta}
+              </Badge>
+            </CardAction>
+          </CardHeader>
+          <CardFooter className="flex-col items-start gap-1.5 text-sm">
+            <div className="line-clamp-1 flex gap-2 font-medium">
+              {metric.comment}
+              {metric.deltaType === "increase" ? (
+                <TrendingUp className="size-4" />
+              ) : (
+                <TrendingDown className="size-4" />
+              )}
+            </div>
+            <div className="text-muted-foreground">{metric.subcomment}</div>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- provide API route for cost metrics
- display KPI metrics in Costi dashboard
- implement generic KPI card group

## Testing
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684dac67f1488325adb48bb42e0f9231