### PR TITLE
Add costi metrics API route

### DIFF
--- a/src/app/api/dashboard/costi-metrics/route.test.ts
+++ b/src/app/api/dashboard/costi-metrics/route.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const mockFrom = vi.fn().mockResolvedValue([
+    { totalEur: "10", total: "10", newCustomers: "1", activeAccounts: "1" },
+  ]);
+  const mockSelect = vi.fn(() => ({ from: mockFrom }));
+  return { db: { select: mockSelect } };
+});
+vi.mock("@/lib/schema", () => ({ receiptsLive: {} }));
+
+import { GET } from "./route";
+
+describe("dashboard costi metrics API", () => {
+  it("returns metrics keys", async () => {
+    const res = await GET();
+    const json = await res.json();
+    expect(json).toHaveProperty("totalRevenue");
+    expect(json).toHaveProperty("newCustomers");
+    expect(json).toHaveProperty("activeAccounts");
+    expect(json).toHaveProperty("growthRate");
+  });
+});

--- a/src/app/api/dashboard/costi-metrics/route.ts
+++ b/src/app/api/dashboard/costi-metrics/route.ts
@@ -1,0 +1,23 @@
+import { db } from "@/lib/db";
+import { receiptsLive } from "@/lib/schema";
+import { sum, count, countDistinct } from "drizzle-orm/sql";
+
+export async function GET() {
+  const [row] = await db
+    .select({
+      totalEur: sum(receiptsLive.totalEur),
+      total: sum(receiptsLive.total),
+      newCustomers: countDistinct(receiptsLive.name),
+      activeAccounts: count(receiptsLive.id),
+    })
+    .from(receiptsLive);
+
+  const metrics = {
+    totalRevenue: Number(row?.totalEur ?? row?.total ?? 0),
+    newCustomers: Number(row?.newCustomers ?? 0),
+    activeAccounts: Number(row?.activeAccounts ?? 0),
+    growthRate: "+0%",
+  };
+
+  return Response.json(metrics);
+}


### PR DESCRIPTION
## Summary
- implement `/api/dashboard/costi-metrics` route to expose revenue metrics
- compute totals using drizzle-orm aggregations
- simple vitest unit test for the API handler

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684dac64a818832583c43a65b17188fe