### PR TITLE
Add reusable KPI card group component

### DIFF
--- a/src/app/(main)/dashboard/_components/kpi-card-group.tsx
+++ b/src/app/(main)/dashboard/_components/kpi-card-group.tsx
@@ -1,0 +1,48 @@
+import { TrendingDown, TrendingUp } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardAction, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+export interface KpiItem {
+  title: string;
+  value: string;
+  delta?: string;
+  trend: "up" | "down";
+  message: string;
+  subtext: string;
+}
+
+interface KpiCardGroupProps {
+  readonly items: KpiItem[];
+}
+
+export function KpiCardGroup({ items }: KpiCardGroupProps) {
+  return (
+    <div className="*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+      {items.map((item) => (
+        <Card key={item.title} className="@container/card">
+          <CardHeader>
+            <CardDescription>{item.title}</CardDescription>
+            <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
+              {item.value}
+            </CardTitle>
+            {item.delta && (
+              <CardAction>
+                <Badge variant="outline">
+                  {item.trend === "up" ? <TrendingUp /> : <TrendingDown />}
+                  {item.delta}
+                </Badge>
+              </CardAction>
+            )}
+          </CardHeader>
+          <CardFooter className="flex-col items-start gap-1.5 text-sm">
+            <div className="line-clamp-1 flex gap-2 font-medium">
+              {item.message} {item.trend === "up" ? <TrendingUp className="size-4" /> : <TrendingDown className="size-4" />}
+            </div>
+            <div className="text-muted-foreground">{item.subtext}</div>
+          </CardFooter>
+        </Card>
+      ))
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/andamento/_components/section-cards.tsx
+++ b/src/app/(main)/dashboard/andamento/_components/section-cards.tsx
@@ -1,83 +1,40 @@
-import { TrendingUp, TrendingDown } from "lucide-react";
-
-import { Badge } from "@/components/ui/badge";
-import { Card, CardAction, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { KpiCardGroup, type KpiItem } from "../../_components/kpi-card-group";
 
 export function SectionCards() {
-  return (
-    <div className="*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
-      <Card className="@container/card">
-        <CardHeader>
-          <CardDescription>Total Revenue</CardDescription>
-          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">$1,250.00</CardTitle>
-          <CardAction>
-            <Badge variant="outline">
-              <TrendingUp />
-              +12.5%
-            </Badge>
-          </CardAction>
-        </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Trending up this month <TrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">Visitors for the last 6 months</div>
-        </CardFooter>
-      </Card>
-      <Card className="@container/card">
-        <CardHeader>
-          <CardDescription>New Customers</CardDescription>
-          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">1,234</CardTitle>
-          <CardAction>
-            <Badge variant="outline">
-              <TrendingDown />
-              -20%
-            </Badge>
-          </CardAction>
-        </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Down 20% this period <TrendingDown className="size-4" />
-          </div>
-          <div className="text-muted-foreground">Acquisition needs attention</div>
-        </CardFooter>
-      </Card>
-      <Card className="@container/card">
-        <CardHeader>
-          <CardDescription>Active Accounts</CardDescription>
-          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">45,678</CardTitle>
-          <CardAction>
-            <Badge variant="outline">
-              <TrendingUp />
-              +12.5%
-            </Badge>
-          </CardAction>
-        </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Strong user retention <TrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">Engagement exceed targets</div>
-        </CardFooter>
-      </Card>
-      <Card className="@container/card">
-        <CardHeader>
-          <CardDescription>Growth Rate</CardDescription>
-          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">4.5%</CardTitle>
-          <CardAction>
-            <Badge variant="outline">
-              <TrendingUp />
-              +4.5%
-            </Badge>
-          </CardAction>
-        </CardHeader>
-        <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Steady performance increase <TrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">Meets growth projections</div>
-        </CardFooter>
-      </Card>
-    </div>
-  );
+  const items: KpiItem[] = [
+    {
+      title: "Total Revenue",
+      value: "$1,250.00",
+      delta: "+12.5%",
+      trend: "up",
+      message: "Trending up this month",
+      subtext: "Visitors for the last 6 months",
+    },
+    {
+      title: "New Customers",
+      value: "1,234",
+      delta: "-20%",
+      trend: "down",
+      message: "Down 20% this period",
+      subtext: "Acquisition needs attention",
+    },
+    {
+      title: "Active Accounts",
+      value: "45,678",
+      delta: "+12.5%",
+      trend: "up",
+      message: "Strong user retention",
+      subtext: "Engagement exceed targets",
+    },
+    {
+      title: "Growth Rate",
+      value: "4.5%",
+      delta: "+4.5%",
+      trend: "up",
+      message: "Steady performance increase",
+      subtext: "Meets growth projections",
+    },
+  ];
+
+  return <KpiCardGroup items={items} />;
 }


### PR DESCRIPTION
## Summary
- create `KpiCardGroup` to render KPI cards from props
- use the new component in `SectionCards`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dac6195788325963a69a1e3575717