### PR TITLE
Fix closing brace in KpiCardGroup

### DIFF
--- a/src/app/(main)/dashboard/_components/kpi-card-group.tsx
+++ b/src/app/(main)/dashboard/_components/kpi-card-group.tsx
@@ -42,7 +42,7 @@ export function KpiCardGroup({ items }: KpiCardGroupProps) {
             <div className="text-muted-foreground">{item.subtext}</div>
           </CardFooter>
         </Card>
-      ))
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- correct `KpiCardGroup` closing brace so JSX compiles

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684db1840eb08325a5825cf6bd467907