### PR TITLE
Add costi dashboard metrics

### DIFF
--- a/src/app/(main)/dashboard/_components/kpi-card-group.tsx
+++ b/src/app/(main)/dashboard/_components/kpi-card-group.tsx
@@ -23,9 +23,7 @@ export function KpiCardGroup({ items }: KpiCardGroupProps) {
         <Card key={item.title} className="@container/card">
           <CardHeader>
             <CardDescription>{item.title}</CardDescription>
-            <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-              {item.value}
-            </CardTitle>
+            <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">{item.value}</CardTitle>
             {item.delta && (
               <CardAction>
                 <Badge variant="outline">
@@ -37,12 +35,13 @@ export function KpiCardGroup({ items }: KpiCardGroupProps) {
           </CardHeader>
           <CardFooter className="flex-col items-start gap-1.5 text-sm">
             <div className="line-clamp-1 flex gap-2 font-medium">
-              {item.message} {item.trend === "up" ? <TrendingUp className="size-4" /> : <TrendingDown className="size-4" />}
+              {item.message}{" "}
+              {item.trend === "up" ? <TrendingUp className="size-4" /> : <TrendingDown className="size-4" />}
             </div>
             <div className="text-muted-foreground">{item.subtext}</div>
           </CardFooter>
         </Card>
-      ))
+      ))}
     </div>
   );
 }

--- a/src/app/(main)/dashboard/costi/page.tsx
+++ b/src/app/(main)/dashboard/costi/page.tsx
@@ -1,3 +1,53 @@
-export default function Page() {
-  return <div className="@container/main flex flex-col gap-4 md:gap-6" />;
+import { KpiCardGroup, type KpiItem } from "../_components/kpi-card-group";
+
+export default async function Page() {
+  const res = await fetch("/api/dashboard/costi-metrics");
+  const data: {
+    totalRevenue: number;
+    newCustomers: number;
+    activeAccounts: number;
+    growthRate: string;
+  } = await res.json();
+
+  const items: KpiItem[] = [
+    {
+      title: "Total Revenue",
+      value: data.totalRevenue.toLocaleString("it-IT", {
+        style: "currency",
+        currency: "EUR",
+      }),
+      delta: data.growthRate,
+      trend: data.growthRate.startsWith("-") ? "down" : "up",
+      message: data.growthRate.startsWith("-") ? "Trending down this month" : "Trending up this month",
+      subtext: "Aggregated from receipts",
+    },
+    {
+      title: "New Customers",
+      value: data.newCustomers.toLocaleString("it-IT"),
+      trend: "up",
+      message: "Customers so far",
+      subtext: "Distinct contacts in receipts",
+    },
+    {
+      title: "Active Accounts",
+      value: data.activeAccounts.toLocaleString("it-IT"),
+      trend: "up",
+      message: "Total receipts logged",
+      subtext: "Entries in receipts_live",
+    },
+    {
+      title: "Growth Rate",
+      value: data.growthRate,
+      delta: data.growthRate,
+      trend: data.growthRate.startsWith("-") ? "down" : "up",
+      message: data.growthRate.startsWith("-") ? "Growth trending down" : "Growth trending up",
+      subtext: "Compared to last period",
+    },
+  ];
+
+  return (
+    <div className="@container/main flex flex-col gap-4 md:gap-6">
+      <KpiCardGroup items={items} />
+    </div>
+  );
 }

--- a/src/app/api/dashboard/costi-metrics/route.ts
+++ b/src/app/api/dashboard/costi-metrics/route.ts
@@ -1,6 +1,7 @@
+import { sum, count, countDistinct } from "drizzle-orm/sql";
+
 import { db } from "@/lib/db";
 import { receiptsLive } from "@/lib/schema";
-import { sum, count, countDistinct } from "drizzle-orm/sql";
 
 export async function GET() {
   const [row] = await db


### PR DESCRIPTION
## Summary
- server-render `/dashboard/costi` and display metrics from `/api/dashboard/costi-metrics`
- close JSX map in `KpiCardGroup`
- fix API route import order for lint

## Testing
- `npm test`
- `npx next lint --dir src`

------
https://chatgpt.com/codex/tasks/task_e_684db18776708325abff0eee2e607f28