### PR TITLE
Fix vitest by mocking drizzle module

### DIFF
--- a/src/app/api/dashboard/costi-metrics/route.test.ts
+++ b/src/app/api/dashboard/costi-metrics/route.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("@/lib/db", () => {
-  const mockFrom = vi.fn().mockResolvedValue([
-    { totalEur: "10", total: "10", newCustomers: "1", activeAccounts: "1" },
-  ]);
+  const mockFrom = vi.fn().mockResolvedValue([{ totalEur: "10", total: "10", newCustomers: "1", activeAccounts: "1" }]);
   const mockSelect = vi.fn(() => ({ from: mockFrom }));
   return { db: { select: mockSelect } };
 });
 vi.mock("@/lib/schema", () => ({ receiptsLive: {} }));
+vi.mock("drizzle-orm/sql", () => ({
+  sum: vi.fn(),
+  count: vi.fn(),
+  countDistinct: vi.fn(),
+}));
 
 import { GET } from "./route";
 


### PR DESCRIPTION
## Summary
- mock `drizzle-orm/sql` in the dashboard costi metrics tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684db18c83348325bfb3d31718f4249e