### PR TITLE
Add DB URL check

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,14 @@ To set up and run this admin dashboard locally, follow these steps:
    > While installing, you may be prompted to use the `--force` or `--legacy-peer-deps` flag.  
    > This is expected and safe — it’s due to a dependency from the Shadcn registry that references a breaking library version.
 
-3. **Start the development server**
+3. **Configure environment variables**
+   Set up a `.env.local` file (or export variables in your shell) with your database connection string:
+   ```bash
+   DATABASE_URL=<your-postgres-connection>
+   ```
+   Some providers expose this value as `POSTGRES_URL`. If so, rename or duplicate it as `DATABASE_URL`.
+
+4. **Start the development server**
    ```bash
    npm run dev
    ```

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,6 +1,11 @@
 import { createPool } from "@vercel/postgres";
 import { drizzle } from "drizzle-orm/vercel-postgres";
 
-const pool = createPool({ connectionString: process.env.DATABASE_URL });
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL not configured");
+}
+
+const pool = createPool({ connectionString: databaseUrl });
 
 export const db = drizzle(pool);


### PR DESCRIPTION
## Summary
- check `process.env.DATABASE_URL` when creating the pool
- document how to set `DATABASE_URL` (or `POSTGRES_URL`) in the README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db64e4ad48325b6b4a9d287e5c296