### PR TITLE
Fix build error from stray CSS text

### DIFF
--- a/src/app/(main)/dashboard/archivio/page.tsx
+++ b/src/app/(main)/dashboard/archivio/page.tsx
@@ -10,7 +10,7 @@ import React, { ReactNode } from "react";
 interface ArchivioPageProps {
   /**
    * Keep any existing children or page sections here.
-   * If you already render specific components on this page, 
+   * If you already render specific components on this page,
    * simply move them inside the <MainContent> wrapper below.
    */
   children?: ReactNode;
@@ -18,9 +18,7 @@ interface ArchivioPageProps {
 
 export default function ArchivioPage({ children }: ArchivioPageProps) {
   return (
-    <main
-      className="min-h-screen w-full bg-[url('/sfondo-matrix.png')] bg-cover bg-center bg-no-repeat"
-    >
+    <main className="min-h-screen w-full bg-[url('/sfondo-matrix.png')] bg-cover bg-center bg-no-repeat">
       {/* Overlay (optional) – remove if you don’t need a dark tint */}
       <div className="absolute inset-0 bg-black/40" aria-hidden="true" />
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,7 @@
-/* ──────────────────────────────────────────────────────────────Add commentMore actions
+/* ──────────────────────────────────────────────────────────────
    src/app/globals.css – v2
    Global stylesheet for the Next.js app (Tailwind v4)
    ----------------------------------------------------------- */
-
 
 /* Tailwind directives */
 @tailwind base;
@@ -10,7 +9,6 @@
 @tailwind utilities;
 
 /* Experimental dark variant (kept from original) */
-
 
 @custom-variant dark (&:is(.dark *));
 
@@ -129,7 +127,7 @@
    ----------------------------------------------------------------- */
 @layer base {
   * {
-    @apply border-border outline-ring/50;Add commentMore actions
+    @apply border-border outline-ring/50;
   }
 
   body {


### PR DESCRIPTION
## Summary
- remove extraneous text from `src/app/globals.css`
- tidy comment in Archivio page without trailing whitespace

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd17a8e5883258452f935acdcc75f