### PR TITLE
Handle missing database url

### DIFF
--- a/src/app/api/dashboard/costi-metrics/route.ts
+++ b/src/app/api/dashboard/costi-metrics/route.ts
@@ -1,9 +1,18 @@
 import { sum, count, countDistinct } from "drizzle-orm/sql";
 
-import { db } from "@/lib/db";
 import { receiptsLive } from "@/lib/schema";
 
 export async function GET() {
+  if (!process.env.DATABASE_URL) {
+    return Response.json({
+      totalRevenue: 0,
+      newCustomers: 0,
+      activeAccounts: 0,
+      growthRate: "+0%",
+    });
+  }
+
+  const { db } = await import("@/lib/db");
   const [row] = await db
     .select({
       totalEur: sum(receiptsLive.totalEur),


### PR DESCRIPTION
## Summary
- avoid import error when `DATABASE_URL` is not configured

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Irregular whitespace not allowed, import/order, prettier issues, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684e2c47253c83259d4756d836a65abd