### PR TITLE
Remove deprecated pnpm path addition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install pnpm
-        run: |
-          npm install -g pnpm
-          echo "$(npm root -g)/pnpm" >> $GITHUB_PATH
+        run: npm install -g pnpm
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary
- drop the `echo` usage in workflow

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint` *(fails: Irregular whitespace not allowed, prefer nullish coalescing, etc.)*
- `pnpm run build` *(fails: Next.js build worker exited with code: 1)*
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_684e321fe4208325a742db392194f739