### PR TITLE
Fix types for andamento dashboard table

### DIFF
--- a/src/app/(main)/dashboard/andamento/_components/columns.tsx
+++ b/src/app/(main)/dashboard/andamento/_components/columns.tsx
@@ -24,39 +24,26 @@
 import { ColumnDef } from "@tanstack/react-table";
 
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
-import { ReceiptRowActions } from "@/components/table/row-actions";
+import { SectionRowActions } from "@/components/table/row-actions";
 import { Checkbox } from "@/components/ui/checkbox";
 
 // ────────────────────────────────────────────────────────────
 //  Tipi
 // ────────────────────────────────────────────────────────────
-export interface ReceiptRow {
-  id: string;
-  date: string; // YYYY-MM-DD
-  time?: string; // HH:mm
-  name: string; // intestazione / fornitore
-  country?: string; // IT, FR, US …
-  currency: string; // codice ISO (EUR, USD …)
-  tip?: number; // eventuale mancia
-  total: number; // importo originale
-  exchange_rate?: number; // cambio verso EUR (1 unit currency = ? EUR)
-  total_eur: number; // importo convertito in €
-  percent?: number; // campo libero (+%)
+export interface SectionRow {
+  id: number;
+  header: string;
+  type: string;
+  status: string;
+  target: string;
+  limit: string;
+  reviewer: string;
 }
-
-// ────────────────────────────────────────────────────────────
-//  Helpers
-// ────────────────────────────────────────────────────────────
-const fmtDate = (d: string) => new Date(d).toLocaleDateString("it-IT");
-const fmtTime = (t?: string) => t ?? "—";
-const fmtCurr = (val: number, curr = "EUR") =>
-  Intl.NumberFormat("it-IT", { style: "currency", currency: curr }).format(val);
-const fmtNum = (val?: number) => val ?? "—";
 
 // ────────────────────────────────────────────────────────────
 //  Definizione colonne
 // ────────────────────────────────────────────────────────────
-export const dashboardColumns: ColumnDef<ReceiptRow>[] = [
+export const dashboardColumns: ColumnDef<SectionRow>[] = [
   // Checkbox di selezione (fissa)
   {
     id: "select",
@@ -82,73 +69,49 @@ export const dashboardColumns: ColumnDef<ReceiptRow>[] = [
     accessorKey: "id",
     header: ({ column }) => <DataTableColumnHeader column={column} title="ID" />,
     cell: ({ row }) => row.original.id,
-    size: 140,
-  },
-  {
-    accessorKey: "date",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Data" />,
-    cell: ({ row }) => fmtDate(row.original.date),
-    size: 110,
-  },
-  {
-    accessorKey: "time",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Ora" />,
-    cell: ({ row }) => fmtTime(row.original.time),
     size: 80,
   },
   {
-    accessorKey: "name",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Nome" />,
-    cell: ({ row }) => row.original.name,
+    accessorKey: "header",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Header" />,
+    cell: ({ row }) => row.original.header,
     size: 220,
   },
   {
-    accessorKey: "country",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Nazione" />,
-    cell: ({ row }) => row.original.country ?? "—",
-    size: 100,
+    accessorKey: "type",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Type" />,
+    cell: ({ row }) => row.original.type,
+    size: 150,
   },
   {
-    accessorKey: "currency",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Valuta" />,
-    cell: ({ row }) => row.original.currency,
+    accessorKey: "status",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
+    cell: ({ row }) => row.original.status,
+    size: 150,
+  },
+  {
+    accessorKey: "target",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Target" />,
+    cell: ({ row }) => row.original.target,
     size: 90,
   },
   {
-    accessorKey: "tip",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Tip/Mancia" />,
-    cell: ({ row }) => fmtNum(row.original.tip),
-    size: 110,
-  },
-  {
-    accessorKey: "total",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Totale" />,
-    cell: ({ row }) => fmtCurr(row.original.total, row.original.currency),
-    size: 110,
-  },
-  {
-    accessorKey: "exchange_rate",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Cambio" />,
-    cell: ({ row }) => (row.original.exchange_rate ? row.original.exchange_rate.toFixed(4) : "—"),
+    accessorKey: "limit",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Limit" />,
+    cell: ({ row }) => row.original.limit,
     size: 90,
   },
   {
-    accessorKey: "total_eur",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="Totale (€)" />,
-    cell: ({ row }) => fmtCurr(row.original.total_eur, "EUR"),
-    size: 120,
-  },
-  {
-    accessorKey: "percent",
-    header: ({ column }) => <DataTableColumnHeader column={column} title="+ %" />,
-    cell: ({ row }) => (row.original.percent !== undefined ? row.original.percent + "%" : "—"),
-    size: 70,
+    accessorKey: "reviewer",
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Reviewer" />,
+    cell: ({ row }) => row.original.reviewer,
+    size: 180,
   },
   // Azioni (fissa a destra)
   {
     id: "actions",
     header: () => <span className="sr-only">Azioni</span>,
-    cell: ({ row }) => <ReceiptRowActions row={row.original} />,
+    cell: ({ row }) => <SectionRowActions row={row.original} />,
     enableSorting: false,
     enableHiding: false,
     size: 60,

--- a/src/app/(main)/dashboard/andamento/_components/data-table.tsx
+++ b/src/app/(main)/dashboard/andamento/_components/data-table.tsx
@@ -13,7 +13,6 @@ import {
 } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { Plus } from "lucide-react";
-import { z } from "zod";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -27,19 +26,9 @@ import { DataTablePagination } from "../../../../../components/data-table/data-t
 import { DataTableViewOptions } from "../../../../../components/data-table/data-table-view-options";
 import { withDndColumn } from "../../../../../components/data-table/table-utils";
 
-import { dashboardColumns } from "./columns";
+import { dashboardColumns, type SectionRow } from "./columns";
 
-export const schema = z.object({
-  id: z.number(),
-  header: z.string(),
-  type: z.string(),
-  status: z.string(),
-  target: z.string(),
-  limit: z.string(),
-  reviewer: z.string(),
-});
-
-export function DataTable({ data: initialData }: { data: z.infer<typeof schema>[] }) {
+export function DataTable({ data: initialData }: { data: SectionRow[] }) {
   const dndEnabled = true;
 
   const [data, setData] = React.useState(() => initialData);

--- a/src/app/(main)/dashboard/andamento/page.tsx
+++ b/src/app/(main)/dashboard/andamento/page.tsx
@@ -1,5 +1,5 @@
 import { ChartAreaInteractive } from "./_components/chart-area-interactive";
-import type { ReceiptRow } from "./_components/columns";
+import type { SectionRow } from "./_components/columns";
 import { DataTable } from "./_components/data-table";
 import data from "./_components/data.json";
 import { SectionCards } from "./_components/section-cards";
@@ -9,7 +9,7 @@ export default function Page() {
     <div className="@container/main flex flex-col gap-4 md:gap-6">
       <SectionCards />
       <ChartAreaInteractive />
-      <DataTable data={data as unknown as ReceiptRow[]} />
+      <DataTable data={data as unknown as SectionRow[]} />
     </div>
   );
 }

--- a/src/components/table/row-actions.tsx
+++ b/src/components/table/row-actions.tsx
@@ -2,7 +2,7 @@
 
 import { Copy, Edit, MoreHorizontal, Trash } from "lucide-react";
 
-import type { ReceiptRow } from "@/app/(main)/dashboard/andamento/_components/columns";
+import type { SectionRow } from "@/app/(main)/dashboard/andamento/_components/columns";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-export function ReceiptRowActions({ row }: { row: ReceiptRow }) {
+export function SectionRowActions({ row }: { row: SectionRow }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary
- align andamento dashboard table types with its sample data
- update row actions and page to use `SectionRow`

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: next not found)*
- `pnpm build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508a51d9748325bc4eeb76257049e6