### PR TITLE
Fix SectionRow imports

### DIFF
--- a/src/app/(main)/dashboard/andamento/page.tsx
+++ b/src/app/(main)/dashboard/andamento/page.tsx
@@ -1,5 +1,5 @@
 import { ChartAreaInteractive } from "./_components/chart-area-interactive";
-import type { SectionRow } from "./_components/columns";
+import type { ReceiptRow } from "./_components/columns";
 import { DataTable } from "./_components/data-table";
 import data from "./_components/data.json";
 import { SectionCards } from "./_components/section-cards";
@@ -9,7 +9,7 @@ export default function Page() {
     <div className="@container/main flex flex-col gap-4 md:gap-6">
       <SectionCards />
       <ChartAreaInteractive />
-      <DataTable data={data as unknown as SectionRow[]} />
+      <DataTable data={data as unknown as ReceiptRow[]} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- adjust Andamento dashboard page to import `ReceiptRow`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d999b2dc8325840098ec3493b279