### PR TITLE
Fix TableMeta generic mismatch

### DIFF
--- a/src/app/(main)/dashboard/costi/_components/columns.tsx
+++ b/src/app/(main)/dashboard/costi/_components/columns.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, type RowData } from "@tanstack/react-table";
 
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { SectionRowActions } from "@/components/table/row-actions";
@@ -9,7 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 //  Fix TypeScript: estendi TableMeta per updateData
 // ────────────────────────────────────────────────────────────
 declare module '@tanstack/react-table' {
-  interface TableMeta<TData extends object> {
+  interface TableMeta<TData extends RowData> {
     updateData: (rowIndex: number, columnId: string, value: any) => void;
   }
 }


### PR DESCRIPTION
## Summary
- import `RowData` in the costi columns
- ensure `TableMeta` extension uses the same generic constraint as the library

## Testing
- `pnpm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685108c4a5308325a7be6b134e6edb79