### PR TITLE
Fix TableMeta typing in costi columns

### DIFF
--- a/src/app/(main)/dashboard/costi/_components/columns.tsx
+++ b/src/app/(main)/dashboard/costi/_components/columns.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, RowData } from "@tanstack/react-table";
 
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { SectionRowActions } from "@/components/table/row-actions";
@@ -9,7 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 //  Fix TypeScript: estendi TableMeta per updateData
 // ────────────────────────────────────────────────────────────
 declare module '@tanstack/react-table' {
-  interface TableMeta<TData extends object> {
+  interface TableMeta<TData extends RowData> {
     updateData: (rowIndex: number, columnId: string, value: any) => void;
   }
 }


### PR DESCRIPTION
## Summary
- import `RowData` from `@tanstack/react-table`
- update the module augmentation to constrain `TableMeta` with `RowData`

## Testing
- `pnpm install`
- `pnpm run build` *(fails: DATABASE_URL not configured)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6851125247d483259409e7b9723c77af