### PR TITLE
Fix dashboard costi import order and tailwind classes

### DIFF
--- a/src/app/(main)/dashboard/costi/page.tsx
+++ b/src/app/(main)/dashboard/costi/page.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import * as React from "react";
-import DataTable, { CostRow } from "./_components/DataTableResizable";
+
 import data from "./_components/data.json";
+import DataTable, { CostRow } from "./_components/DataTableResizable";
 import { SectionCards } from "./_components/section-cards";
 
 export default function CostiPage() {
   const rows: CostRow[] = data as unknown as CostRow[];
 
   return (
-    <div className="@container/main flex flex-col gap-4 md:gap-6 p-6">
+    <div className="@container/main flex flex-col gap-4 p-6 md:gap-6">
       <SectionCards />
-      <h1 className="text-2xl font-bold mb-2">Dashboard Costi</h1>
+      <h1 className="mb-2 text-2xl font-bold">Dashboard Costi</h1>
       <DataTable data={rows} />
     </div>
   );


### PR DESCRIPTION
## Summary
- fix import order in `costi/page.tsx`
- tidy tailwind class ordering in dashboard costi page

## Testing
- `pnpm lint` *(fails: project has other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68512ca649188325ad7802f0630c5c02