### PR TITLE
Fix costi dashboard page import

### DIFF
--- a/src/app/(main)/dashboard/costi/page.tsx
+++ b/src/app/(main)/dashboard/costi/page.tsx
@@ -1,4 +1,6 @@
-import type { ReceiptRow } from "./_components/columns";
+import { ChartAreaInteractive } from "../andamento/_components/chart-area-interactive";
+
+import type { CostiRow } from "./_components/columns";
 import { DataTable } from "./_components/data-table";
 import data from "./_components/data.json";
 import { SectionCards } from "./_components/section-cards";
@@ -8,7 +10,7 @@ export default function Page() {
     <div className="@container/main flex flex-col gap-4 md:gap-6">
       <SectionCards />
       <ChartAreaInteractive />
-      <DataTable data={data as unknown as ReceiptRow[]} />
+      <DataTable data={data as unknown as CostiRow[]} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add missing ChartAreaInteractive import to `costi` dashboard page
- use `CostiRow` type

## Testing
- `DATABASE_URL=postgres://user:pass@localhost/db pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6852e49839f08325b30324b2af3e2f39