### PR TITLE
Add missing chart area import

### DIFF
--- a/src/app/(main)/dashboard/costi/page.tsx
+++ b/src/app/(main)/dashboard/costi/page.tsx
@@ -1,3 +1,5 @@
+import { ChartAreaInteractive } from "../andamento/_components/chart-area-interactive";
+
 import type { CostiRow } from "./_components/columns";
 import { DataTable } from "./_components/data-table";
 import data from "./_components/data.json";


### PR DESCRIPTION
## Summary
- add ChartAreaInteractive import for Costi dashboard

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6852f40740fc8325be6f5b7c52719953