### PR TITLE
Add Google credentials env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Example environment configuration
 # Copy this file to .env and fill in your actual database connection string
 DATABASE_URL=postgres://USER:PASSWORD@HOST/DATABASE?sslmode=require
+
+# JSON credentials for Google Cloud Vision
+GOOGLE_APPLICATION_CREDENTIALS_JSON=<your-google-json>

--- a/README.md
+++ b/README.md
@@ -146,17 +146,21 @@ You have two equivalent ways to provide the required environment variables – 
 
    ```bash
    cp .env.example .env
-   # then open .env and set your real values
+   # then open .env and set your real values for
+   # DATABASE_URL and GOOGLE_APPLICATION_CREDENTIALS_JSON
    ```
 
 2. **Create (or append to) a local‑only environment file**
 
-   Set up a file such as `.env.local` (or export variables directly in your shell) with at least your database connection string:
+   Set up a file such as `.env.local` (or export variables directly in your shell) with at least your database connection string and Google service account credentials:
 
    ```bash
    # example .env.local
    DATABASE_URL=<your-postgres-connection>
+   GOOGLE_APPLICATION_CREDENTIALS_JSON=<your-google-json>
    ```
+
+   `GOOGLE_APPLICATION_CREDENTIALS_JSON` stores the JSON for the Google Cloud Vision service account used by the OCR API route.
 
    > **Note** Some providers expose this value as `POSTGRES_URL`. If so, rename or duplicate it as `DATABASE_URL` so the application can find it.
 


### PR DESCRIPTION
## Summary
- document `GOOGLE_APPLICATION_CREDENTIALS_JSON` usage in setup instructions
- add placeholder for the variable in `.env.example`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: React lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68536de33f508325b4fa0a45a23a2549