### PR TITLE
Add OPENAI API key placeholder and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ DATABASE_URL=postgres://USER:PASSWORD@HOST/DATABASE?sslmode=require
 
 # JSON credentials for Google Cloud Vision
 GOOGLE_APPLICATION_CREDENTIALS_JSON=<your-google-json>
+
+# OpenAI API key
+OPENAI_API_KEY=<your-openai-key>

--- a/README.md
+++ b/README.md
@@ -152,17 +152,18 @@ You have two equivalent ways to provide the required environment variables – 
    ```bash
    cp .env.example .env
    # then open .env and set your real values for
-   # DATABASE_URL and GOOGLE_APPLICATION_CREDENTIALS_JSON
+   # DATABASE_URL, GOOGLE_APPLICATION_CREDENTIALS_JSON and OPENAI_API_KEY
    ```
 
 2. **Create (or append to) a local‑only environment file**
 
-   Set up a file such as `.env.local` (or export variables directly in your shell) with at least your database connection string and Google service account credentials:
+   Set up a file such as `.env.local` (or export variables directly in your shell) with at least your database connection string, Google service account credentials, and OpenAI key:
 
    ```bash
    # example .env.local
    DATABASE_URL=<your-postgres-connection>
    GOOGLE_APPLICATION_CREDENTIALS_JSON=<your-google-json>
+   OPENAI_API_KEY=<your-openai-key>
    ```
 
    `GOOGLE_APPLICATION_CREDENTIALS_JSON` stores the JSON for the Google Cloud Vision service account used by the OCR API route.


### PR DESCRIPTION
## Summary
- add placeholder `OPENAI_API_KEY` in sample env file
- document `OPENAI_API_KEY` in environment setup section of README

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e6a77c708325949d974f558e89ac