### PR TITLE
Fix OCR route type import

### DIFF
--- a/src/app/api/ocr/route.ts
+++ b/src/app/api/ocr/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { v1 as vision } from "@google-cloud/vision";
+import { protos } from "@google-cloud/vision/build/protos/protos";
 import { OpenAI } from "openai";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { v4 as uuidv4 } from "uuid";
@@ -24,7 +25,7 @@ function safeJsonParse<T>(input: string): T | null {
   }
 }
 
-function extractText(result: vision.protos.google.cloud.vision.v1.IAnnotateImageResponse) {
+function extractText(result: protos.google.cloud.vision.v1.IAnnotateImageResponse) {
   return result.textAnnotations?.[0]?.description ?? result.fullTextAnnotation?.text ?? "";
 }
 


### PR DESCRIPTION
## Summary
- update OCR endpoint to import `protos`
- type `extractText` parameter using `protos` instead of `vision.protos`

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855ed458d2483258312097070f1d5dc