### PR TITLE
Fix OCR route vision protos import

### DIFF
--- a/src/app/api/ocr/route.ts
+++ b/src/app/api/ocr/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { v1 as vision } from "@google-cloud/vision";
-import { protos } from "@google-cloud/vision/build/protos/protos";
+import { v1 as vision, protos } from "@google-cloud/vision";
 import { OpenAI } from "openai";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { v4 as uuidv4 } from "uuid";


### PR DESCRIPTION
## Summary
- import `protos` from `@google-cloud/vision`
- drop obsolete import path

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855f23080488325bc01984732252adf