### PR TITLE
Persist OCR results

### DIFF
--- a/src/app/api/ocr/route.ts
+++ b/src/app/api/ocr/route.ts
@@ -95,5 +95,15 @@ Se non riesci a trovare un campo, lascia stringa vuota o null, MA il JSON deve e
   dati.id = dati.id || uuidv4();
   dati.filename = fileName;
 
+  try {
+    await fetch(`${req.nextUrl.origin}/api/receipts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(dati),
+    });
+  } catch (err) {
+    console.error("Failed to persist OCR result", err);
+  }
+
   return NextResponse.json(dati);
 }

--- a/src/app/api/receipts/route.test.ts
+++ b/src/app/api/receipts/route.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+var mockInsert: any;
+var mockValues: any;
+
+vi.mock("@/lib/db", () => {
+  mockValues = vi.fn();
+  mockInsert = vi.fn(() => ({ values: mockValues }));
+  return { db: { insert: mockInsert } };
+});
+vi.mock("@/lib/schema", () => ({ receiptsLive: {} }));
+
+import { POST } from "./route";
+
+describe("receipts POST API", () => {
+  it("inserts data into receipts_live", async () => {
+    const req = { json: vi.fn().mockResolvedValue({ id: "1", date: "2024-01-01", currency: "EUR", total: 10, source_hash: "x" }) } as unknown as NextRequest;
+    const res = await POST(req);
+    expect(mockInsert).toHaveBeenCalledWith(expect.anything());
+    expect(mockValues).toHaveBeenCalled();
+    const json = await res.json();
+    expect(json).toEqual({ success: true });
+  });
+});

--- a/src/app/api/receipts/route.ts
+++ b/src/app/api/receipts/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { receiptsLive } from "@/lib/schema";
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+
+  const row = {
+    id: data.id,
+    date: data.date ? new Date(data.date) : undefined,
+    time: data.time ?? null,
+    name: data.name,
+    country: data.country ?? null,
+    currency: data.currency,
+    total: data.total,
+    tip: data.tip ?? null,
+    exchangeRate: data.exchange_rate ?? null,
+    totalEur: data.total_eur ?? null,
+    percent: data.percent ?? null,
+    paymentMethod: data.payment_method ?? null,
+    status: data.status ?? "new",
+    sourceHash: data.source_hash ?? data.id,
+  } as any;
+
+  await db.insert(receiptsLive).values(row);
+  return NextResponse.json({ success: true });
+}


### PR DESCRIPTION
## Summary
- store parsed OCR results via `/api/receipts`
- persist data from OCR handler by calling the new API
- test new receipts API

## Testing
- `pnpm lint` *(fails: Next.js lint added suggestions and exits with code 1)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68560a5793c0832594ce6b9f5e427496