### PR TITLE
Fix receipts archive constraint name

### DIFF
--- a/drizzle/0000_futuristic_vapor.sql
+++ b/drizzle/0000_futuristic_vapor.sql
@@ -15,7 +15,7 @@ CREATE TABLE "receipts_archive" (
 	"source_hash" text NOT NULL,
 	"created_at" timestamp DEFAULT now(),
 	"archived_at" timestamp DEFAULT now(),
-	CONSTRAINT "receipts_live_source_hash_unique" UNIQUE("source_hash")
+        CONSTRAINT "receipts_archive_source_hash_unique" UNIQUE("source_hash")
 );
 --> statement-breakpoint
 CREATE TABLE "receipts_live" (

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -113,8 +113,8 @@
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
-        "receipts_live_source_hash_unique": {
-          "name": "receipts_live_source_hash_unique",
+        "receipts_archive_source_hash_unique": {
+          "name": "receipts_archive_source_hash_unique",
           "nullsNotDistinct": false,
           "columns": [
             "source_hash"

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -113,8 +113,8 @@
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
-        "receipts_live_source_hash_unique": {
-          "name": "receipts_live_source_hash_unique",
+        "receipts_archive_source_hash_unique": {
+          "name": "receipts_archive_source_hash_unique",
           "nullsNotDistinct": false,
           "columns": [
             "source_hash"


### PR DESCRIPTION
## Summary
- rename receipts_archive's unique constraint for source_hash
- keep receipts_live's constraint name unchanged

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856188a3154832595624aac3debfcba