### PR TITLE
Fix receipts_archive unique constraint metadata

### DIFF
--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -113,8 +113,8 @@
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
-        "receipts_live_source_hash_unique": {
-          "name": "receipts_live_source_hash_unique",
+        "receipts_archive_source_hash_unique": {
+          "name": "receipts_archive_source_hash_unique",
           "nullsNotDistinct": false,
           "columns": [
             "source_hash"

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -113,8 +113,8 @@
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
-        "receipts_live_source_hash_unique": {
-          "name": "receipts_live_source_hash_unique",
+        "receipts_archive_source_hash_unique": {
+          "name": "receipts_archive_source_hash_unique",
           "nullsNotDistinct": false,
           "columns": [
             "source_hash"


### PR DESCRIPTION
## Summary
- update the unique constraint for `receipts_archive` in the initial snapshot
- regenerate the second snapshot so the constraint name stays consistent

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561893491883258d17d01968650767