### PR TITLE
Make migrations optional and document push script

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,12 @@ You have two equivalent ways to provide the required environment variables – 
 
    > **Note** Some providers expose this value as `POSTGRES_URL`. If so, rename or duplicate it as `DATABASE_URL` so the application can find it.
 
-4. **Start the development server**
+4. **Apply database migrations**
+   ```bash
+   pnpm run push:migrations
+   ```
+
+5. **Start the development server**
    ```bash
    pnpm dev
    ```

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,8 @@
+import path from "path";
+
 import { createPool } from "@vercel/postgres";
 import { drizzle } from "drizzle-orm/vercel-postgres";
 import { migrate } from "drizzle-orm/vercel-postgres/migrator";
-import path from "path";
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
@@ -12,5 +13,7 @@ const pool = createPool({ connectionString: databaseUrl });
 
 export const db = drizzle(pool);
 
-const migrationsFolder = path.join(process.cwd(), "drizzle");
-await migrate(db, { migrationsFolder });
+if (process.env.RUN_MIGRATIONS === "true") {
+  const migrationsFolder = path.join(process.cwd(), "drizzle");
+  await migrate(db, { migrationsFolder });
+}


### PR DESCRIPTION
## Summary
- allow running migrations only when `RUN_MIGRATIONS` is `true`
- add README notes about manually applying migrations with `pnpm run push:migrations`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: import order and other style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68561897d848832595e1e56fc8fc8305