### PR TITLE
Fix missing table error by running migrations

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,7 @@
 import { createPool } from "@vercel/postgres";
 import { drizzle } from "drizzle-orm/vercel-postgres";
+import { migrate } from "drizzle-orm/vercel-postgres/migrator";
+import path from "path";
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
@@ -9,3 +11,6 @@ if (!databaseUrl) {
 const pool = createPool({ connectionString: databaseUrl });
 
 export const db = drizzle(pool);
+
+const migrationsFolder = path.join(process.cwd(), "drizzle");
+await migrate(db, { migrationsFolder });


### PR DESCRIPTION
## Summary
- automatically run migrations when initializing the database

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm format` *(fails: cannot find prettier plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68561181cdcc83259aee4136ce9010f3