### PR TITLE
Handle fetch errors in dashboard costs page

### DIFF
--- a/src/app/(main)/dashboard/costi/page.test.ts
+++ b/src/app/(main)/dashboard/costi/page.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../andamento/_components/chart-area-interactive", () => ({ ChartAreaInteractive: {} }));
+vi.mock("./_components/data-table", () => ({ DataTable: {} }));
+vi.mock("./_components/section-cards", () => ({ SectionCards: {} }));
+
+import { getRows } from "./page";
+
+// Ensure fetch is restored after tests
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("getRows", () => {
+  it("throws when the API response is not ok", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("fail", { status: 500, statusText: "Server Error" }));
+    // @ts-expect-error: stub global fetch
+    global.fetch = mockFetch;
+
+    await expect(getRows()).rejects.toThrow();
+  });
+});

--- a/src/app/(main)/dashboard/costi/page.tsx
+++ b/src/app/(main)/dashboard/costi/page.tsx
@@ -41,9 +41,23 @@ async function getRows(): Promise<CostiRow[]> {
   const res = await fetch(`${baseUrl}/api/receipts/history`, {
     cache: "no-store",
   });
+
+  if (!res.ok) {
+    let message: string;
+    try {
+      message = await res.text();
+    } catch {
+      message = res.statusText;
+    }
+    console.error("Error fetching receipts history:", message);
+    throw new Error(message);
+  }
+
   const rows = (await res.json()) as ApiRow[];
   return rows.map(mapRow);
 }
+
+export { getRows };
 
 export default async function Page() {
   const data = await getRows();


### PR DESCRIPTION
## Summary
- ensure the `getRows` helper checks `fetch` success
- expose `getRows` and test it

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68561c2a3f4c8325acd3c1d06a431e20