### PR TITLE
Add error handling to receipts history route

### DIFF
--- a/src/app/api/receipts/history/route.test.ts
+++ b/src/app/api/receipts/history/route.test.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from "next/server";
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/db", () => {
+  const mockOrderBy = vi.fn().mockRejectedValue(new Error("fail"));
+  const mockWhere = vi.fn(() => ({ orderBy: mockOrderBy }));
+  const mockFrom = vi.fn(() => ({ where: mockWhere }));
+  const mockSelect = vi.fn(() => ({ from: mockFrom }));
+  return { db: { select: mockSelect } };
+});
+vi.mock("@/lib/schema", () => ({ receiptsLive: {} }));
+
+import { GET } from "./route";
+
+describe("receipts history GET API", () => {
+  it("returns 500 on database error", async () => {
+    const req = { url: "http://example.com/api/receipts/history" } as NextRequest;
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json).toEqual({ error: "Database error" });
+  });
+});

--- a/src/app/api/receipts/history/route.ts
+++ b/src/app/api/receipts/history/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+
 import { eq, and, gte, lte } from "drizzle-orm";
+
 import { db } from "@/lib/db";
 import { receiptsLive } from "@/lib/schema";
 
@@ -13,20 +15,17 @@ export async function GET(req: NextRequest) {
   // Costruisci condizioni dinamiche
   let where = undefined;
   if (from && to) {
-  const fromDate = new Date(from + "T00:00:00.000Z");
-  const toDate = new Date(to + "T23:59:59.999Z");
-  where = and(
-    gte(receiptsLive.createdAt, fromDate),
-    lte(receiptsLive.createdAt, toDate)
-    );
+    const fromDate = new Date(from + "T00:00:00.000Z");
+    const toDate = new Date(to + "T23:59:59.999Z");
+    where = and(gte(receiptsLive.createdAt, fromDate), lte(receiptsLive.createdAt, toDate));
   }
 
   // Query Drizzle (prende tutto se where è undefined)
-  const rows = await db
-    .select()
-    .from(receiptsLive)
-    .where(where)
-    .orderBy(receiptsLive.createdAt);
-
-  return NextResponse.json(rows);
+  try {
+    const rows = await db.select().from(receiptsLive).where(where).orderBy(receiptsLive.createdAt);
+    return NextResponse.json(rows);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Database error" }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Summary
- add DB error handling for receipts history API
- test 500 response when DB query fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68561c2c7e708325a8329fdc783eea63