### PR TITLE
Remove automatic migration and add manual script

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ You have two equivalent ways to provide the required environment variables – 
 
 4. **Apply database migrations**
    ```bash
-   pnpm run push:migrations
+   pnpm run migrate
    ```
+   Run this once before starting the server or as part of your deployment.
 
 5. **Start the development server**
    ```bash

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:ui": "vitest --ui",
     "prepare": "husky",
     "generate:migrations": "drizzle-kit generate --schema=./lib/schema.ts --out=./drizzle",
-    "push:migrations": "drizzle-kit push --schema=./lib/schema.ts --out=./drizzle"
+    "push:migrations": "drizzle-kit push --schema=./lib/schema.ts --out=./drizzle",
+    "migrate": "pnpm run push:migrations"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,8 +1,5 @@
-import path from "path";
-
 import { createPool } from "@vercel/postgres";
 import { drizzle } from "drizzle-orm/vercel-postgres";
-import { migrate } from "drizzle-orm/vercel-postgres/migrator";
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
@@ -12,8 +9,3 @@ if (!databaseUrl) {
 const pool = createPool({ connectionString: databaseUrl });
 
 export const db = drizzle(pool);
-
-if (process.env.RUN_MIGRATIONS === "true") {
-  const migrationsFolder = path.join(process.cwd(), "drizzle");
-  await migrate(db, { migrationsFolder });
-}


### PR DESCRIPTION
## Summary
- remove `migrate()` call from `db.ts`
- add `migrate` script for manual DB migration
- document running migrations in README

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68561c2d34e08325aba5246eff20e8fa