### PR TITLE
Handle DB migrations more safely

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -13,4 +13,12 @@ const pool = createPool({ connectionString: databaseUrl });
 export const db = drizzle(pool);
 
 const migrationsFolder = path.join(process.cwd(), "drizzle");
-await migrate(db, { migrationsFolder });
+
+if (process.env.NODE_ENV !== "production") {
+  try {
+    await migrate(db, { migrationsFolder });
+  } catch (error) {
+    console.error("Failed to run database migrations", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- wrap the `migrate` call in a try/catch block
- log errors and skip running migrations in production

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6856206d477083258f11caaa6b2cef52