### PR TITLE
Fix receipt date type mismatch

### DIFF
--- a/src/app/api/receipts/route.ts
+++ b/src/app/api/receipts/route.ts
@@ -5,13 +5,12 @@ import { InferInsertModel } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { receiptsLive } from "@/lib/schema";
 
-// eslint-disable-next-line complexity
 export async function POST(req: NextRequest) {
   const data = await req.json();
 
   const row: InferInsertModel<typeof receiptsLive> = {
     id: data.id,
-    date: data.date ? new Date(data.date) : undefined,
+    date: data.date ? new Date(data.date) : new Date(),
     time: data.time ?? null,
     name: data.name,
     country: data.country ?? null,


### PR DESCRIPTION
## Summary
- fix POST /api/receipts date field typing

## Testing
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68576da9520c8325b2a9fe1a49c17bb5