### PR TITLE
[studio-admin] Fix column names in history API

### DIFF
--- a/src/app/api/receipts/history/route.ts
+++ b/src/app/api/receipts/history/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+
 import { and, gte, lte } from "drizzle-orm";
 
 import { db } from "@/lib/db";
@@ -29,10 +30,10 @@ export async function GET(req: NextRequest) {
         currency: receiptsLive.currency,
         tip: receiptsLive.tip,
         total: receiptsLive.total,
-        exchangeRate: receiptsLive.exchange_rate, 
-        totalEur: receiptsLive.total_eur,
+        exchangeRate: receiptsLive.exchangeRate,
+        totalEur: receiptsLive.totalEur,
         percent: receiptsLive.percent,
-        imageUrl: receiptsLive.image_url,         
+        imageUrl: receiptsLive.imageUrl,
       })
       .from(receiptsLive)
       .where(where)


### PR DESCRIPTION
## Summary
- use camelCase column accessors for history API

## Testing
- `pnpm lint` *(fails: Unsupported engine + lint errors)*
- `pnpm test` *(fails: 1 failing test)*
- `pnpm build` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b345780988325aa89fb7522c0c05c