### PR TITLE
[studio-admin] configure exchange API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ VERCEL_TOKEN=
 # Vercel Project ID (for deployment/watch automations)
 PROJECT_ID=
 
+# Base URL for currency conversion API (default https://api.exchangerate.host)
+NEXT_PUBLIC_EXCHANGE_RATE_URL=https://api.exchangerate.host
+

--- a/README.md
+++ b/README.md
@@ -72,4 +72,20 @@ This project includes an **AI watcher script** (`ai-deploy-watcher.js`) that aut
   node ai-deploy-watcher.js
   ```
 
-  Ensure the environment variables `VERCEL_TOKEN`, `PROJECT_ID`, and `OPENAI_API_KEY` are set before running the script.
+Ensure the environment variables `VERCEL_TOKEN`, `PROJECT_ID`, and `OPENAI_API_KEY` are set before running the script.
+
+---
+
+## Network Access for Currency Rates
+
+Currency conversion is handled via [api.exchangerate.host](https://api.exchangerate.host). When using the provided devcontainer the container runs with `--network host`, so external API requests work out of the box.
+
+If you run the project in your own Docker setup make sure the container can reach this API (for example by adding `--network host`).
+
+For local development you can override or proxy the service by setting `NEXT_PUBLIC_EXCHANGE_RATE_URL` in your `.env` file:
+
+```sh
+NEXT_PUBLIC_EXCHANGE_RATE_URL=https://api.exchangerate.host
+```
+
+If not set, it defaults to `https://api.exchangerate.host`.

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -78,14 +78,23 @@ export function normalizeCurrency(input: string): string {
 }
 
 // Fetch current exchange rate: how many units of `currency` equal 1 EUR
+const EXCHANGE_BASE =
+  process.env.NEXT_PUBLIC_EXCHANGE_RATE_URL ??
+  "https://api.exchangerate.host";
+
 export async function fetchExchangeRate(currency: string): Promise<number> {
-  if (!currency || normalizeCurrency(currency) === "EUR") return 1;
+  if (!currency || normalizeCurrency(currency) === "EUR") {
+    return 1;
+  }
+
   try {
     const to = normalizeCurrency(currency);
     const res = await fetch(
-      `https://api.exchangerate.host/convert?from=EUR&to=${to}&amount=1`
+      `${EXCHANGE_BASE.replace(/\/$/, "")}/convert?from=EUR&to=${to}&amount=1`
     );
-    if (!res.ok) return 0;
+    if (!res.ok) {
+      return 0;
+    }
     const data = await res.json();
     return data?.info?.rate ?? data?.result ?? 0;
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow overriding exchange rate API via `NEXT_PUBLIC_EXCHANGE_RATE_URL`
- document network access and env var configuration

## Testing
- `pnpm test` *(fails: Failed to load module)*
- `pnpm lint` *(fails: numerous lint errors)*
- `pnpm build` *(fails: DATABASE_URL not configured)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b5fa4848325b16d9f9c30fc930c