### PR TITLE
[studio-admin] Document env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,10 @@ VERCEL_TOKEN=
 # Vercel Project ID (for deployment/watch automations)
 PROJECT_ID=
 
+# Supabase project credentials
+SUPABASE_URL=
+SUPABASE_KEY=
+
+# Base site URL for Next.js (used for building links)
+NEXT_PUBLIC_SITE_URL=
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      PROJECT_ID: ${{ secrets.PROJECT_ID }}
+      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/README.md
+++ b/README.md
@@ -73,3 +73,18 @@ This project includes an **AI watcher script** (`ai-deploy-watcher.js`) that aut
   ```
 
   Ensure the environment variables `VERCEL_TOKEN`, `PROJECT_ID`, and `OPENAI_API_KEY` are set before running the script.
+
+---
+
+## Environment Variables
+
+Copy `.env.example` to `.env.local` (or set these values as repository/Vercel secrets) before running the project.
+
+- `DATABASE_URL` – PostgreSQL connection string
+- `SUPABASE_URL` – Supabase project URL
+- `SUPABASE_KEY` – Supabase service role key
+- `GOOGLE_API_KEY` – Google Cloud Vision API key
+- `OPENAI_API_KEY` – OpenAI API key
+- `VERCEL_TOKEN` – Vercel API token
+- `PROJECT_ID` – Vercel project ID
+- `NEXT_PUBLIC_SITE_URL` – Base URL used by the frontend


### PR DESCRIPTION
## Summary
- document environment variables in README
- include Supabase and site URL placeholders in `.env.example`
- pass secrets to GitHub Actions build

## Testing
- `pnpm run lint` *(fails: ESLint warnings and errors)*
- `pnpm run build` *(fails: DATABASE_URL not configured)*
- `pnpm run test` *(fails: 1 test failed)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b624c2483259b9beb38aba500a9